### PR TITLE
Update pipeline resources based on a full test

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -13,10 +13,23 @@
 process {
 
     //
+    // General processes
+    //
+
+    withName: 'DROP.*PREPROCESSGENEANNOTATION' {
+        cpus = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    //
     // Aberrant expression
     //
 
     withName: 'DROP.*GENECOUNTS_COUNTREADS' {
+        cpus = { 1 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         tag = { "${meta.id}.${meta.gene_annotation}" }
         ext.prefix = { "${meta.id}.counts" }
         publishDir = [
@@ -27,6 +40,9 @@ process {
     }
 
     withName: 'DROP.*GENECOUNTS_MERGECOUNTS' {
+        cpus = { 30 * task.attempt }
+        memory = { 300.MB * (counts instanceof List ? counts.size() : 1) * task.attempt }
+        time = { 1.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
         ext.prefix = "total_counts"
         publishDir = [
@@ -37,6 +53,9 @@ process {
     }
 
     withName: 'DROP.*GENECOUNTS_FILTERCOUNTS' {
+        cpus = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
         ext.prefix = "ods_unfitted"
         publishDir = [
@@ -46,7 +65,17 @@ process {
         ]
     }
 
+
+    withName: 'DROP.*GENECOUNTS_SUMMARY' {
+        cpus = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
     withName: 'DROP.*OUTRIDER_FIT' {
+        cpus = { 50 * task.attempt }
+        memory = { 60.GB * task.attempt }
+        time = { 5.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
         ext.prefix = "ods_fitted"
         publishDir = [
@@ -57,6 +86,9 @@ process {
     }
 
     withName: 'DROP.*OUTRIDER_PVALS' {
+        cpus = { 10 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
         ext.prefix = "ods"
         publishDir = [
@@ -67,6 +99,9 @@ process {
     }
 
     withName: 'DROP.*OUTRIDER_RESULTS' {
+        cpus = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
         ext.prefix = "OUTRIDER_results"
         publishDir = [
@@ -76,11 +111,56 @@ process {
         ]
     }
 
+    withName: 'DROP.*OUTRIDER_RESULTS' {
+        cpus = { 3 * task.attempt }
+        memory = { 30.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
     //
     // Aberrant splicing
     //
 
+    withName: 'DROP.*SPLICECOUNTS_INIT' {
+        cpus = { 2 * task.attempt }
+        memory = { 5.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    withName: 'DROP.*SPLICECOUNTS_COUNTSPLITREADS' {
+        cpus = { 3 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    withName: 'DROP.*SPLICECOUNTS_MERGESPLITREADS' {
+        cpus = { 20 * task.attempt }
+        memory = { 70.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    withName: 'DROP.*SPLICECOUNTS_COUNTNONSPLITREADS' {
+        cpus = { 3 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    withName: 'DROP.*SPLICECOUNTS_MERGENONSPLITREADS' {
+        cpus = { 20 * task.attempt }
+        memory = { 30.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    withName: 'DROP.*SPLICECOUNTS_COLLECTCOUNTS' {
+        cpus = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
     withName: 'DROP.*FRASER_FILTEREXPRESSION' {
+        cpus = { 3 * task.attempt }
+        memory = { 30.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -89,7 +169,16 @@ process {
         ]
     }
 
+    withName: 'DROP.*FRASER_FITHYPERPARAMS' {
+        cpus = { 12 * task.attempt }
+        memory = { 70.GB * task.attempt }
+        time = { 2.h * task.attempt }
+    }
+
     withName: 'DROP.*FRASER_PSIVALUECALCULATION' {
+        cpus = { 30 * task.attempt }
+        memory = { 85.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -99,6 +188,9 @@ process {
     }
 
     withName: 'DROP.*FRASER_FITAUTOENCODER' {
+        cpus = { 20 * task.attempt }
+        memory = { 70.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -108,6 +200,9 @@ process {
     }
 
     withName: 'DROP.*FRASER_ANNOTATEGENES' {
+        cpus = { 20 * task.attempt }
+        memory = { 40.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -117,6 +212,9 @@ process {
     }
 
     withName: 'DROP.*FRASER_CALCULATESTATS' {
+        cpus = { 20 * task.attempt }
+        memory = { 60.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_results/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -126,6 +224,9 @@ process {
     }
 
     withName: 'DROP.*FRASER_EXTRACTRESULTS' {
+        cpus = { 10 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_results/aberrant_splicing/results/${annotation_id}/fraser/${drop_group}/" },
             mode: params.publish_dir_mode,
@@ -139,6 +240,9 @@ process {
     //
 
     withName: 'DROP.*MAE_CREATESNVS' {
+        cpus = { 3 * task.attempt }
+        memory = { 5.GB * task.attempt }
+        time = { 1.h * task.attempt }
         ext.prefix = { "${meta.dna_id}--${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/processed_data/mae/snvs/" },
@@ -149,6 +253,9 @@ process {
     }
 
     withName: 'DROP.*MAE_ALLELICCOUNTS' {
+        cpus = { 2 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 2.h * task.attempt }
         ext.prefix = { "${meta.dna_id}--${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/processed_data/mae/allelic_counts/" },
@@ -159,6 +266,9 @@ process {
     }
 
     withName: 'DROP.*MAE_DESEQ' {
+        cpus = { 2 * task.attempt }
+        memory = { 20.GB * task.attempt }
+        time = { 1.h * task.attempt }
         ext.prefix = { "${meta.dna_id}--${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/processed_results/mae/samples/" },
@@ -169,6 +279,9 @@ process {
     }
 
     withName: 'DROP.*MAE_GENENAMEMAPPING' {
+        cpus = { 1 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         ext.prefix = { "gene_name_mapping_${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/processed_results/mae/" },
@@ -179,6 +292,9 @@ process {
     }
 
     withName: 'DROP.*MAE_RESULTS' {
+        cpus = { 3 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.annotation}" }
         ext.prefix = { meta.annotation }
         publishDir = [
@@ -190,6 +306,9 @@ process {
     }
 
     withName: 'DROP.*MAEQC_DNARNADESEQ' {
+        cpus = { 3 * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/mae/RNA_GT" },
             mode: params.publish_dir_mode,
@@ -199,6 +318,9 @@ process {
     }
 
     withName: 'DROP.*MAEQC_DNARNAMATRIX' {
+        cpus = { 20 * task.attempt }
+        memory = { 40.GB * task.attempt }
+        time = { 1.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_results/mae/${drop_group}" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -40,7 +40,7 @@ process {
     }
 
     withName: 'DROP.*GENECOUNTS_MERGECOUNTS' {
-        cpus = { 30 * task.attempt }
+        cpus = { 6 * task.attempt }
         memory = { 300.MB * (counts instanceof List ? counts.size() : 1) * task.attempt }
         time = { 1.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
@@ -75,7 +75,7 @@ process {
     withName: 'DROP.*OUTRIDER_FIT' {
         cpus = { 50 * task.attempt }
         memory = { 60.GB * task.attempt }
-        time = { 5.h * task.attempt }
+        time = { 15.h * task.attempt }
         tag = { "${meta.drop_group}.${meta.id}" }
         ext.prefix = "ods_fitted"
         publishDir = [
@@ -111,7 +111,7 @@ process {
         ]
     }
 
-    withName: 'DROP.*OUTRIDER_RESULTS' {
+    withName: 'DROP.*OUTRIDER_SUMMARY' {
         cpus = { 3 * task.attempt }
         memory = { 30.GB * task.attempt }
         time = { 1.h * task.attempt }
@@ -134,7 +134,7 @@ process {
     }
 
     withName: 'DROP.*SPLICECOUNTS_MERGESPLITREADS' {
-        cpus = { 20 * task.attempt }
+        cpus = { 6 * task.attempt }
         memory = { 70.GB * task.attempt }
         time = { 1.h * task.attempt }
     }
@@ -146,7 +146,7 @@ process {
     }
 
     withName: 'DROP.*SPLICECOUNTS_MERGENONSPLITREADS' {
-        cpus = { 20 * task.attempt }
+        cpus = { 6 * task.attempt }
         memory = { 30.GB * task.attempt }
         time = { 1.h * task.attempt }
     }
@@ -159,8 +159,8 @@ process {
 
     withName: 'DROP.*FRASER_FILTEREXPRESSION' {
         cpus = { 3 * task.attempt }
-        memory = { 30.GB * task.attempt }
-        time = { 1.h * task.attempt }
+        memory = { 40.GB * task.attempt }
+        time = { 3.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -170,15 +170,15 @@ process {
     }
 
     withName: 'DROP.*FRASER_FITHYPERPARAMS' {
-        cpus = { 12 * task.attempt }
+        cpus = { 30 * task.attempt }
         memory = { 70.GB * task.attempt }
-        time = { 2.h * task.attempt }
+        time = { 6.h * task.attempt }
     }
 
     withName: 'DROP.*FRASER_PSIVALUECALCULATION' {
-        cpus = { 30 * task.attempt }
+        cpus = { 4 * task.attempt }
         memory = { 85.GB * task.attempt }
-        time = { 1.h * task.attempt }
+        time = { 3.h * task.attempt }
         publishDir = [
             path: { "${params.outdir}/processed_data/aberrant_splicing/datasets/" },
             mode: params.publish_dir_mode,
@@ -188,7 +188,7 @@ process {
     }
 
     withName: 'DROP.*FRASER_FITAUTOENCODER' {
-        cpus = { 20 * task.attempt }
+        cpus = { 10 * task.attempt }
         memory = { 70.GB * task.attempt }
         time = { 1.h * task.attempt }
         publishDir = [
@@ -200,7 +200,7 @@ process {
     }
 
     withName: 'DROP.*FRASER_ANNOTATEGENES' {
-        cpus = { 20 * task.attempt }
+        cpus = { 10 * task.attempt }
         memory = { 40.GB * task.attempt }
         time = { 1.h * task.attempt }
         publishDir = [
@@ -212,7 +212,7 @@ process {
     }
 
     withName: 'DROP.*FRASER_CALCULATESTATS' {
-        cpus = { 20 * task.attempt }
+        cpus = { 10 * task.attempt }
         memory = { 60.GB * task.attempt }
         time = { 1.h * task.attempt }
         publishDir = [
@@ -253,7 +253,7 @@ process {
     }
 
     withName: 'DROP.*MAE_ALLELICCOUNTS' {
-        cpus = { 2 * task.attempt }
+        cpus = { 1 * task.attempt }
         memory = { 10.GB * task.attempt }
         time = { 2.h * task.attempt }
         ext.prefix = { "${meta.dna_id}--${meta.id}" }
@@ -266,7 +266,7 @@ process {
     }
 
     withName: 'DROP.*MAE_DESEQ' {
-        cpus = { 2 * task.attempt }
+        cpus = { 1 * task.attempt }
         memory = { 20.GB * task.attempt }
         time = { 1.h * task.attempt }
         ext.prefix = { "${meta.dna_id}--${meta.id}" }
@@ -318,7 +318,7 @@ process {
     }
 
     withName: 'DROP.*MAEQC_DNARNAMATRIX' {
-        cpus = { 20 * task.attempt }
+        cpus = { 10 * task.attempt }
         memory = { 40.GB * task.attempt }
         time = { 1.h * task.attempt }
         publishDir = [


### PR DESCRIPTION
This PR updates the pipeline resources based on the reports in #61 

For CPUs I first took a look at the given threads in the snakemake pipeline and compared it with the reported usage, whichever was bigger is used in the config.

For memory and time I took a look at the report per process and updated the defaults based on the maximum values with a margin