### PR TITLE
nf-test-conda-env

### DIFF
--- a/modules/local/fraser/annotategenes/environment.yml
+++ b/modules/local/fraser/annotategenes/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/annotategenes/main.nf
+++ b/modules/local/fraser/annotategenes/main.nf
@@ -5,8 +5,8 @@ process FRASER_ANNOTATEGENES {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), path(txdb), path(gene_name_mapping), val(drop_group), val(annotation_id)

--- a/modules/local/fraser/calculatestats/environment.yml
+++ b/modules/local/fraser/calculatestats/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/calculatestats/main.nf
+++ b/modules/local/fraser/calculatestats/main.nf
@@ -5,8 +5,8 @@ process FRASER_CALCULATESTATS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), val(drop_group), val(annotation_id), val(sample_ids)

--- a/modules/local/fraser/calculatestats/tests/main.nf.test
+++ b/modules/local/fraser/calculatestats/tests/main.nf.test
@@ -50,7 +50,7 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    file_list.findAll { !file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"]},
+                    file_list.findAll { !(file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"])},
                     file_list.findAll { file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"]}.collect { file(it.toString()).name },
                     process.out.versions
                 ).match() }

--- a/modules/local/fraser/calculatestats/tests/main.nf.test
+++ b/modules/local/fraser/calculatestats/tests/main.nf.test
@@ -50,8 +50,8 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    file_list.findAll { !(file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"])},
-                    file_list.findAll { file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"]}.collect { file(it.toString()).name },
+                    file_list.findAll { !(file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_psi5.h5", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"])},
+                    file_list.findAll { file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_psi5.h5", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"]}.collect { file(it.toString()).name },
                     process.out.versions
                 ).match() }
             )

--- a/modules/local/fraser/calculatestats/tests/main.nf.test
+++ b/modules/local/fraser/calculatestats/tests/main.nf.test
@@ -50,8 +50,8 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    file_list.findAll { file(it.toString()).name != "fds-object.RDS"},
-                    file_list.findAll { file(it.toString()).name == "fds-object.RDS"}.collect { file(it.toString()).name },
+                    file_list.findAll { !file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"]},
+                    file_list.findAll { file(it.toString()).name in ["fds-object.RDS", "pvaluesBetaBinomial_theta.h5", "pvaluesBetaBinomial_junction_psi5.h5", "pvaluesBetaBinomial_junction_theta.h5"]}.collect { file(it.toString()).name },
                     process.out.versions
                 ).match() }
             )

--- a/modules/local/fraser/calculatestats/tests/main.nf.test.snap
+++ b/modules/local/fraser/calculatestats/tests/main.nf.test.snap
@@ -2,42 +2,13 @@
     "homo_sapiens - fds, cache - false": {
         "content": [
             [
-                "delta_jaccard.h5:md5,b02262cdbe16d757e8f1b4845d7309da",
-                "delta_psi3.h5:md5,86e9e11b158f3319b655fb8b86ca53d1",
-                "delta_psi5.h5:md5,773d12bcf117b8bf6e9f0bdc5c094cf1",
-                "delta_theta.h5:md5,567bda0ee5b017e1f3560785dfeb9b05",
-                "jaccard.h5:md5,2a65b5f0548d8c165fe19408dca72e64",
-                "padjBetaBinomial_Sample_specific_genes_psi3.h5:md5,8c726b4ac0b89a69e06e7af16032aa19",
-                "padjBetaBinomial_Sample_specific_genes_psi5.h5:md5,bd276981f6e786e56dd6fbefd0cd2d80",
-                "padjBetaBinomial_Sample_specific_genes_theta.h5:md5,a48d289ead83b65a03b57982f5e24ece",
-                "padjBetaBinomial_Test_subset_psi3.h5:md5,3b8e42fb527a8df3e3fe8134601f8eaa",
-                "padjBetaBinomial_Test_subset_psi5.h5:md5,5260a7ce2224c377982f873567b71053",
-                "padjBetaBinomial_Test_subset_theta.h5:md5,d30ab4db089ba5cfb63976c2ed350ca2",
-                "padjBetaBinomial_psi3.h5:md5,e2977bf4621c25aa028994c93ba022a3",
-                "padjBetaBinomial_psi5.h5:md5,891ad620fec1c576abe7a0fe09c1ab94",
-                "padjBetaBinomial_theta.h5:md5,3d197d8f05a07cf6265d3c4e544eb9b7",
-                "predictedMeans_psi3.h5:md5,9761babe89e5bf64b9d1fe52ce096b45",
-                "predictedMeans_psi5.h5:md5,0e8778d36d61e381ffa29047b98a6ea2",
-                "predictedMeans_theta.h5:md5,df10fdbd61c2ceaf9ba64c33b49d0ff5",
-                "psi3.h5:md5,e4718d51a2deba1a3eac0dd0ecfe725a",
-                "psi5.h5:md5,bc4a333776535472090ad585e8e006ef",
-                "pvaluesBetaBinomial_junction_psi3.h5:md5,2c40c6916d6a674ac797f7eb9af1f3e0",
-                "pvaluesBetaBinomial_junction_psi5.h5:md5,bf4a9ea1d840bfda7133e3af9be12066",
-                "pvaluesBetaBinomial_junction_theta.h5:md5,4df41aabd4e876d2c965916e515ad793",
-                "pvaluesBetaBinomial_psi3.h5:md5,ce595a8ef6d382859108f9f23eb7cd58",
-                "pvaluesBetaBinomial_psi5.h5:md5,0e176c189b747394b1a135a137fd81cd",
-                "pvaluesBetaBinomial_theta.h5:md5,f09966dd529f5d54cb4c3be1d8190554",
-                "rawCountsJ.h5:md5,64f8b27cc8cb2bc47de81f0a8cdf51e5",
-                "rawCountsJnonsplit.h5:md5,769e925164bf81231c9b325954171e6a",
-                "rawCountsSS.h5:md5,1bd7d5c2256f1c509142d8a779929f01",
-                "rawOtherCounts_jaccard.h5:md5,d58d42e65dff22a86e4351aa47d493a8",
-                "rawOtherCounts_psi3.h5:md5,bd03f8c0b41ef75dc1359dc7a68cd803",
-                "rawOtherCounts_psi5.h5:md5,0180d3be300d91d89a2015a5e11e84ca",
-                "rawOtherCounts_theta.h5:md5,5bb65524e01020eae46c765c31feadf0",
-                "theta.h5:md5,45e4ee34c95792a5b15f566fcadeee21"
+                
             ],
             [
-                "fds-object.RDS"
+                "fds-object.RDS",
+                "pvaluesBetaBinomial_junction_psi5.h5",
+                "pvaluesBetaBinomial_junction_theta.h5",
+                "pvaluesBetaBinomial_theta.h5"
             ],
             [
                 "versions.yml:md5,c2230506da2802610cc2143196972faf"
@@ -47,7 +18,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T13:33:08.458817805"
+        "timestamp": "2025-09-09T09:58:18.08229867"
     },
     "homo_sapiens - fds, cache - stub": {
         "content": [

--- a/modules/local/fraser/calculatestats/tests/main.nf.test.snap
+++ b/modules/local/fraser/calculatestats/tests/main.nf.test.snap
@@ -2,7 +2,36 @@
     "homo_sapiens - fds, cache - false": {
         "content": [
             [
-                
+                "delta_jaccard.h5:md5,b02262cdbe16d757e8f1b4845d7309da",
+                "delta_psi3.h5:md5,86e9e11b158f3319b655fb8b86ca53d1",
+                "delta_psi5.h5:md5,773d12bcf117b8bf6e9f0bdc5c094cf1",
+                "delta_theta.h5:md5,567bda0ee5b017e1f3560785dfeb9b05",
+                "jaccard.h5:md5,2a65b5f0548d8c165fe19408dca72e64",
+                "padjBetaBinomial_Sample_specific_genes_psi3.h5:md5,8c726b4ac0b89a69e06e7af16032aa19",
+                "padjBetaBinomial_Sample_specific_genes_psi5.h5:md5,bd276981f6e786e56dd6fbefd0cd2d80",
+                "padjBetaBinomial_Sample_specific_genes_theta.h5:md5,a48d289ead83b65a03b57982f5e24ece",
+                "padjBetaBinomial_Test_subset_psi3.h5:md5,3b8e42fb527a8df3e3fe8134601f8eaa",
+                "padjBetaBinomial_Test_subset_psi5.h5:md5,5260a7ce2224c377982f873567b71053",
+                "padjBetaBinomial_Test_subset_theta.h5:md5,d30ab4db089ba5cfb63976c2ed350ca2",
+                "padjBetaBinomial_psi3.h5:md5,e2977bf4621c25aa028994c93ba022a3",
+                "padjBetaBinomial_psi5.h5:md5,891ad620fec1c576abe7a0fe09c1ab94",
+                "padjBetaBinomial_theta.h5:md5,3d197d8f05a07cf6265d3c4e544eb9b7",
+                "predictedMeans_psi3.h5:md5,9761babe89e5bf64b9d1fe52ce096b45",
+                "predictedMeans_psi5.h5:md5,0e8778d36d61e381ffa29047b98a6ea2",
+                "predictedMeans_theta.h5:md5,df10fdbd61c2ceaf9ba64c33b49d0ff5",
+                "psi3.h5:md5,e4718d51a2deba1a3eac0dd0ecfe725a",
+                "psi5.h5:md5,bc4a333776535472090ad585e8e006ef",
+                "pvaluesBetaBinomial_junction_psi3.h5:md5,2c40c6916d6a674ac797f7eb9af1f3e0",
+                "pvaluesBetaBinomial_psi3.h5:md5,ce595a8ef6d382859108f9f23eb7cd58",
+                "pvaluesBetaBinomial_psi5.h5:md5,700a15553f7900b61a939620e382ee3d",
+                "rawCountsJ.h5:md5,64f8b27cc8cb2bc47de81f0a8cdf51e5",
+                "rawCountsJnonsplit.h5:md5,769e925164bf81231c9b325954171e6a",
+                "rawCountsSS.h5:md5,1bd7d5c2256f1c509142d8a779929f01",
+                "rawOtherCounts_jaccard.h5:md5,d58d42e65dff22a86e4351aa47d493a8",
+                "rawOtherCounts_psi3.h5:md5,bd03f8c0b41ef75dc1359dc7a68cd803",
+                "rawOtherCounts_psi5.h5:md5,0180d3be300d91d89a2015a5e11e84ca",
+                "rawOtherCounts_theta.h5:md5,5bb65524e01020eae46c765c31feadf0",
+                "theta.h5:md5,45e4ee34c95792a5b15f566fcadeee21"
             ],
             [
                 "fds-object.RDS",
@@ -18,7 +47,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-09T09:58:18.08229867"
+        "timestamp": "2025-09-09T10:52:27.181626046"
     },
     "homo_sapiens - fds, cache - stub": {
         "content": [

--- a/modules/local/fraser/calculatestats/tests/main.nf.test.snap
+++ b/modules/local/fraser/calculatestats/tests/main.nf.test.snap
@@ -23,7 +23,6 @@
                 "psi5.h5:md5,bc4a333776535472090ad585e8e006ef",
                 "pvaluesBetaBinomial_junction_psi3.h5:md5,2c40c6916d6a674ac797f7eb9af1f3e0",
                 "pvaluesBetaBinomial_psi3.h5:md5,ce595a8ef6d382859108f9f23eb7cd58",
-                "pvaluesBetaBinomial_psi5.h5:md5,700a15553f7900b61a939620e382ee3d",
                 "rawCountsJ.h5:md5,64f8b27cc8cb2bc47de81f0a8cdf51e5",
                 "rawCountsJnonsplit.h5:md5,769e925164bf81231c9b325954171e6a",
                 "rawCountsSS.h5:md5,1bd7d5c2256f1c509142d8a779929f01",
@@ -37,6 +36,7 @@
                 "fds-object.RDS",
                 "pvaluesBetaBinomial_junction_psi5.h5",
                 "pvaluesBetaBinomial_junction_theta.h5",
+                "pvaluesBetaBinomial_psi5.h5",
                 "pvaluesBetaBinomial_theta.h5"
             ],
             [
@@ -47,7 +47,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-09T10:52:27.181626046"
+        "timestamp": "2025-09-09T12:24:11.592076778"
     },
     "homo_sapiens - fds, cache - stub": {
         "content": [

--- a/modules/local/fraser/extractresults/environment.yml
+++ b/modules/local/fraser/extractresults/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/extractresults/main.nf
+++ b/modules/local/fraser/extractresults/main.nf
@@ -5,8 +5,8 @@ process FRASER_EXTRACTRESULTS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: 'input/savedObjects/*'), path(txdb), val(drop_group), val(annotation_id), val(sample_ids)

--- a/modules/local/fraser/filterexpression/environment.yml
+++ b/modules/local/fraser/filterexpression/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/filterexpression/main.nf
+++ b/modules/local/fraser/filterexpression/main.nf
@@ -5,8 +5,8 @@ process FRASER_FILTEREXPRESSION {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), path(splice_counts_dirs), val(external_count_ids), val(drop_group)

--- a/modules/local/fraser/fitautoencoder/environment.yml
+++ b/modules/local/fraser/fitautoencoder/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/fitautoencoder/main.nf
+++ b/modules/local/fraser/fitautoencoder/main.nf
@@ -5,8 +5,8 @@ process FRASER_FITAUTOENCODER {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), val(drop_group)

--- a/modules/local/fraser/fithyperparams/environment.yml
+++ b/modules/local/fraser/fithyperparams/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/fithyperparams/main.nf
+++ b/modules/local/fraser/fithyperparams/main.nf
@@ -5,8 +5,8 @@ process FRASER_FITHYPERPARAMS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs:'input/savedObjects/*'), val(drop_group)

--- a/modules/local/fraser/psivaluecalculation/environment.yml
+++ b/modules/local/fraser/psivaluecalculation/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/fraser/psivaluecalculation/main.nf
+++ b/modules/local/fraser/psivaluecalculation/main.nf
@@ -5,8 +5,8 @@ process FRASER_PSIVALUECALCULATION {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), val(drop_group)

--- a/modules/local/genecounts/filtercounts/environment.yml
+++ b/modules/local/genecounts/filtercounts/environment.yml
@@ -2,8 +2,17 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - conda-forge::r-base=4.4.3
+  - conda-forge::r-magrittr=2.0.3
+  - conda-forge::r-data.table=1.17.0
+  - conda-forge::r-ggplot2=3.5.2
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-ggthemes=5.1.0
+  - conda-forge::r-tidyr=1.3.1
   - bioconda::bioconductor-outrider=1.24.0
   - bioconda::bioconductor-summarizedexperiment=1.36.0
-  - conda-forge::r-base=4.4.3
-  - conda-forge::r-data.table=1.17.2
+  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - bioconda::bioconductor-genomicalignments=1.42.0

--- a/modules/local/genecounts/filtercounts/main.nf
+++ b/modules/local/genecounts/filtercounts/main.nf
@@ -4,8 +4,8 @@ process GENECOUNTS_FILTERCOUNTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a9/a971e624aad46fc672638427d28931d13257642ce54743d6a3869d305eecd642/data' :
-        'community.wave.seqera.io/library/bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-data.table:c6ad593656300741' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7c/7ce5b3968fffff40e5f0ee411b06d26c117985c558d976181e5b3d8575bf3b89/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:536d062a9b8ef2c5' }"
 
     input:
     tuple val(meta), path(counts), path(txdb)

--- a/modules/local/genecounts/filtercounts/tests/main.nf.test.snap
+++ b/modules/local/genecounts/filtercounts/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,237af4cb32fc299f301693e1f4565f2a"
+                    "versions.yml:md5,681cd82b10d316d96d35806516538a0a"
                 ],
                 "output": [
                     [
@@ -22,7 +22,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,237af4cb32fc299f301693e1f4565f2a"
+                    "versions.yml:md5,681cd82b10d316d96d35806516538a0a"
                 ]
             }
         ],
@@ -30,7 +30,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T15:22:11.287646879"
+        "timestamp": "2025-09-10T19:11:27.995254344"
     },
     "homo_sapiens - counts - stub": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,237af4cb32fc299f301693e1f4565f2a"
+                    "versions.yml:md5,681cd82b10d316d96d35806516538a0a"
                 ],
                 "output": [
                     [
@@ -55,7 +55,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,237af4cb32fc299f301693e1f4565f2a"
+                    "versions.yml:md5,681cd82b10d316d96d35806516538a0a"
                 ]
             }
         ],
@@ -63,6 +63,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T15:22:23.084950411"
+        "timestamp": "2025-09-10T19:11:46.669247077"
     }
 }

--- a/modules/local/genecounts/mergecounts/main.nf
+++ b/modules/local/genecounts/mergecounts/main.nf
@@ -4,7 +4,7 @@ process GENECOUNTS_MERGECOUNTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/cb/cb2dbc5c5064366648e38ce9b36fe579eaa92c1980b3257c55d3314d330f0a97/data' :
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ec/eca2d19aed7918a344093e4627135c21403e08bb16b730d924cd93ae5b428464/data' :
         'community.wave.seqera.io/library/bioconductor-biocparallel_bioconductor-summarizedexperiment_r-base_r-data.table_pruned:c96d6e13d480e41d' }"
 
     input:

--- a/modules/local/genecounts/summary/environment.yml
+++ b/modules/local/genecounts/summary/environment.yml
@@ -3,12 +3,16 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::r-base=4.4.3
-  - conda-forge::r-cowplot=1.1.3
-  - conda-forge::r-data.table=1.16.4
+  - conda-forge::r-magrittr=2.0.3
+  - conda-forge::r-data.table=1.17.0
   - conda-forge::r-ggplot2=3.5.2
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-cowplot=1.1.3
   - conda-forge::r-ggthemes=5.1.0
   - conda-forge::r-tidyr=1.3.1
-  - bioconda::bioconductor-genomicfeatures=1.58.0
-  - bioconda::bioconductor-genomicalignments=1.42.0
   - bioconda::bioconductor-outrider=1.24.0
   - bioconda::bioconductor-summarizedexperiment=1.36.0
+  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - bioconda::bioconductor-genomicalignments=1.42.0

--- a/modules/local/genecounts/summary/main.nf
+++ b/modules/local/genecounts/summary/main.nf
@@ -4,8 +4,8 @@ process GENECOUNTS_SUMMARY {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ad/ad385f03c087514a33d3c211ea4e4a411175575a4a065e26f8dedcd98ca526af/data' :
-        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:1206f390222d7451' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7c/7ce5b3968fffff40e5f0ee411b06d26c117985c558d976181e5b3d8575bf3b89/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:536d062a9b8ef2c5' }"
 
     input:
     tuple val(meta), path(ods), path(bam_cov)

--- a/modules/local/genecounts/summary/tests/main.nf.test.snap
+++ b/modules/local/genecounts/summary/tests/main.nf.test.snap
@@ -66,14 +66,14 @@
                 ]
             ],
             [
-                "versions.yml:md5,ffd2684898bcc755a28c7f178bbc145a"
+                "versions.yml:md5,5ff1abd8ddb85fb379be796f07ad1afd"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T15:23:21.819822001"
+        "timestamp": "2025-09-10T19:17:54.394310217"
     },
     "homo_sapiens - gtf - stub": {
         "content": [
@@ -93,7 +93,7 @@
                     
                 ],
                 "11": [
-                    "versions.yml:md5,ffd2684898bcc755a28c7f178bbc145a"
+                    "versions.yml:md5,5ff1abd8ddb85fb379be796f07ad1afd"
                 ],
                 "2": [
                     [
@@ -225,7 +225,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,ffd2684898bcc755a28c7f178bbc145a"
+                    "versions.yml:md5,5ff1abd8ddb85fb379be796f07ad1afd"
                 ],
                 "xist_uty": [
                     
@@ -236,6 +236,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T15:23:34.450200374"
+        "timestamp": "2025-09-10T19:18:12.890358522"
     }
 }

--- a/modules/local/mae/alleliccounts/environment.yml
+++ b/modules/local/mae/alleliccounts/environment.yml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - bioconda::bcftools=1.22
   - bioconda::gatk4=4.6.2.0
-  - bioconda::htslib=1.22
-  - bioconda::samtools=1.22
+  - bioconda::htslib=1.22.1
+  - bioconda::samtools=1.22.1

--- a/modules/local/mae/alleliccounts/main.nf
+++ b/modules/local/mae/alleliccounts/main.nf
@@ -4,8 +4,8 @@ process MAE_ALLELICCOUNTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/df/df6c4aa9794afac9bce253cdf10ae357321449acb3ade91f403f06304eec2851/data' :
-        'community.wave.seqera.io/library/bcftools_gatk4_htslib_samtools:255ed784054aa652' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/df/df2fe51e455c97d1598ba04a7d0cf8805a51eee5debda3e608f3a64ff72a261f/data' :
+        'community.wave.seqera.io/library/bcftools_gatk4_htslib_samtools:949037bf07506ba9' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi), path(bam), path(bai), val(id), path(fasta), path(fai), path(dict)

--- a/modules/local/mae/alleliccounts/tests/main.nf.test.snap
+++ b/modules/local/mae/alleliccounts/tests/main.nf.test.snap
@@ -17,8 +17,8 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde",
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde"
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b",
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b"
                 ],
                 "csv": [
                     [
@@ -35,8 +35,8 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde",
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde"
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b",
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b"
                 ]
             }
         ],
@@ -44,7 +44,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-15T17:01:57.613477188"
+        "timestamp": "2025-09-08T15:12:28.484234335"
     },
     "homo_sapiens - vcf, bam - ucsc - stub": {
         "content": [
@@ -64,8 +64,8 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde",
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde"
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b",
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b"
                 ],
                 "csv": [
                     [
@@ -82,8 +82,8 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde",
-                    "versions.yml:md5,79faf12190a12a8464ffd399a8ce5dde"
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b",
+                    "versions.yml:md5,d0a0a87bba7a17b6288b39ab6365cc9b"
                 ]
             }
         ],
@@ -91,6 +91,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-16T14:18:24.24773888"
+        "timestamp": "2025-09-08T15:12:50.877229487"
     }
 }

--- a/modules/local/mae/createsnvs/environment.yml
+++ b/modules/local/mae/createsnvs/environment.yml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - bioconda::bcftools=1.22
   - bioconda::gatk4=4.6.2.0
-  - bioconda::htslib=1.22
-  - bioconda::samtools=1.22
+  - bioconda::htslib=1.22.1
+  - bioconda::samtools=1.22.1

--- a/modules/local/mae/createsnvs/main.nf
+++ b/modules/local/mae/createsnvs/main.nf
@@ -4,8 +4,8 @@ process MAE_CREATESNVS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/df/df6c4aa9794afac9bce253cdf10ae357321449acb3ade91f403f06304eec2851/data' :
-        'community.wave.seqera.io/library/bcftools_gatk4_htslib_samtools:255ed784054aa652' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/df/df2fe51e455c97d1598ba04a7d0cf8805a51eee5debda3e608f3a64ff72a261f/data' :
+        'community.wave.seqera.io/library/bcftools_gatk4_htslib_samtools:949037bf07506ba9' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi), path(bam), path(bai), val(dna_id)

--- a/modules/local/mae/createsnvs/tests/main.nf.test.snap
+++ b/modules/local/mae/createsnvs/tests/main.nf.test.snap
@@ -69,7 +69,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,4a3eb971c33164d2eed2798fd1be420e"
+                    "versions.yml:md5,60ff047f02552ffdb58b013a05f84c5b"
                 ],
                 "tbi": [
                     [
@@ -88,7 +88,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,4a3eb971c33164d2eed2798fd1be420e"
+                    "versions.yml:md5,60ff047f02552ffdb58b013a05f84c5b"
                 ]
             }
         ],
@@ -96,6 +96,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-15T16:03:03.678813025"
+        "timestamp": "2025-09-08T15:24:50.790669357"
     }
 }

--- a/modules/local/mae/deseq/environment.yml
+++ b/modules/local/mae/deseq/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - bioconda::bioconductor-mafdb.gnomad.r2.1.grch38=3.10.0
   - bioconda::bioconductor-mafdb.gnomad.r2.1.hs37d5=3.10.0
+  - bioconda::bioconductor-genomicranges=1.46.0
   - bioconda::r-tmae=1.0.4
   - conda-forge::r-base=4.1.3
   - conda-forge::r-r.utils=2.12.2

--- a/modules/local/mae/deseq/main.nf
+++ b/modules/local/mae/deseq/main.nf
@@ -3,7 +3,6 @@ process MAE_DESEQ {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container 'nf-core/deseqmae:1.0.4'
     container "${ params.add_af ? 'nf-core/deseqmae:1.0.4' :
         workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/45/4561f708be5a850be48042f0d4d21b2a121fa77576604832da55f650da5735b5/data' :

--- a/modules/local/mae/deseq/main.nf
+++ b/modules/local/mae/deseq/main.nf
@@ -3,7 +3,7 @@ process MAE_DESEQ {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ add_af == true ? 'nf-core/deseqmae:1.0.4' :
+    container "${ add_af == true ? 'nf-core/deseqmae:1.0.4b' :
         (workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2a/2a1fe185a170643337ce71d84c9262cf0fe44adb3f2fa51c5cd6007aebeebe18/data' :
         'community.wave.seqera.io/library/bioconductor-genomicranges_r-tmae_r-base_r-r.utils_r-stringr:e9d522a02847448b') }"

--- a/modules/local/mae/deseq/main.nf
+++ b/modules/local/mae/deseq/main.nf
@@ -4,6 +4,10 @@ process MAE_DESEQ {
 
     conda "${moduleDir}/environment.yml"
     container 'nf-core/deseqmae:1.0.4'
+    container "${ params.add_af ? 'nf-core/deseqmae:1.0.4' :
+        workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/45/4561f708be5a850be48042f0d4d21b2a121fa77576604832da55f650da5735b5/data' :
+        'community.wave.seqera.io/library/r-tmae_r-base_r-r.utils_r-stringr:f69c262e49a5a245' }"
 
     input:
     tuple val(meta), path(counts)
@@ -37,9 +41,7 @@ process MAE_DESEQ {
             paste('    r-base:', strsplit(version[['version.string']], ' ')[[1]][3])
             # paste('    r-r.utils:', as.character(packageVersion('R.utils'))),
             # paste('    r-string:', as.character(packageVersion('stringr'))),
-            # paste('    r-tmae:', as.character(packageVersion('tMAE'))),
-            # paste('    bioconductor-mafdb.gnomad-r2.1.grch38:', as.character(packageVersion('MafDb.gnomAD.r2.1.GRCh38'))),
-            # paste('    bioconductor-mafdb.gnomad-r2.1.hs37d5:', as.character(packageVersion('MafDb.gnomAD.r2.1.hs37d5')))
+            # paste('    r-tmae:', as.character(packageVersion('tMAE')))
         ),
     'versions.yml')
     """

--- a/modules/local/mae/deseq/main.nf
+++ b/modules/local/mae/deseq/main.nf
@@ -3,10 +3,10 @@ process MAE_DESEQ {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ params.add_af ? 'nf-core/deseqmae:1.0.4' :
-        workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ params.add_af == true ? 'nf-core/deseqmae:1.0.4' :
+        (workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/45/4561f708be5a850be48042f0d4d21b2a121fa77576604832da55f650da5735b5/data' :
-        'community.wave.seqera.io/library/r-tmae_r-base_r-r.utils_r-stringr:f69c262e49a5a245' }"
+        'community.wave.seqera.io/library/r-tmae_r-base_r-r.utils_r-stringr:f69c262e49a5a245') }"
 
     input:
     tuple val(meta), path(counts)

--- a/modules/local/mae/deseq/main.nf
+++ b/modules/local/mae/deseq/main.nf
@@ -3,7 +3,7 @@ process MAE_DESEQ {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ params.add_af == true ? 'nf-core/deseqmae:1.0.4' :
+    container "${ add_af == true ? 'nf-core/deseqmae:1.0.4' :
         (workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2a/2a1fe185a170643337ce71d84c9262cf0fe44adb3f2fa51c5cd6007aebeebe18/data' :
         'community.wave.seqera.io/library/bioconductor-genomicranges_r-tmae_r-base_r-r.utils_r-stringr:e9d522a02847448b') }"

--- a/modules/local/mae/deseq/main.nf
+++ b/modules/local/mae/deseq/main.nf
@@ -5,8 +5,8 @@ process MAE_DESEQ {
     conda "${moduleDir}/environment.yml"
     container "${ params.add_af == true ? 'nf-core/deseqmae:1.0.4' :
         (workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/45/4561f708be5a850be48042f0d4d21b2a121fa77576604832da55f650da5735b5/data' :
-        'community.wave.seqera.io/library/r-tmae_r-base_r-r.utils_r-stringr:f69c262e49a5a245') }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2a/2a1fe185a170643337ce71d84c9262cf0fe44adb3f2fa51c5cd6007aebeebe18/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicranges_r-tmae_r-base_r-r.utils_r-stringr:e9d522a02847448b') }"
 
     input:
     tuple val(meta), path(counts)

--- a/modules/local/mae/deseq/templates/deseq_mae.R
+++ b/modules/local/mae/deseq/templates/deseq_mae.R
@@ -47,8 +47,6 @@ writeLines(
         paste('    r-base:', strsplit(version[['version.string']], ' ')[[1]][3]),
         paste('    r-r.utils:', as.character(packageVersion('R.utils'))),
         paste('    r-string:', as.character(packageVersion('stringr'))),
-        paste('    r-tmae:', as.character(packageVersion('tMAE'))),
-        paste('    bioconductor-mafdb.gnomad-r2.1.grch38:', as.character(packageVersion('MafDb.gnomAD.r2.1.GRCh38'))),
-        paste('    bioconductor-mafdb.gnomad-r2.1.hs37d5:', as.character(packageVersion('MafDb.gnomAD.r2.1.hs37d5')))
+        paste('    r-tmae:', as.character(packageVersion('tMAE')))
     ),
 'versions.yml')

--- a/modules/local/maeqc/dnarnadeseq/environment.yml
+++ b/modules/local/maeqc/dnarnadeseq/environment.yml
@@ -2,7 +2,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::bioconductor-genomicranges=1.58.0
-  - bioconda::r-tmae=1.0.5
-  - conda-forge::r-base=4.4.3
-  - conda-forge::r-r.utils=2.13.0
+  - bioconda::bioconductor-genomicranges=1.46.0
+  - bioconda::r-tmae=1.0.4
+  - conda-forge::r-base=4.1.3
+  - conda-forge::r-r.utils=2.12.2
+  - conda-forge::r-stringr=1.5.0

--- a/modules/local/maeqc/dnarnadeseq/main.nf
+++ b/modules/local/maeqc/dnarnadeseq/main.nf
@@ -4,8 +4,8 @@ process MAEQC_DNARNADESEQ {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a2/a20e81a37e3e4376534cf7a225da72640b35674961fb3317e4e72c0177d0ac32/data' :
-        'community.wave.seqera.io/library/bioconductor-genomicranges_r-tmae_r-base_r-r.utils:153fb7526c2a316a' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/2a/2a1fe185a170643337ce71d84c9262cf0fe44adb3f2fa51c5cd6007aebeebe18/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicranges_r-tmae_r-base_r-r.utils_r-stringr:e9d522a02847448b' }"
 
     input:
     tuple val(meta), path(counts)

--- a/modules/local/maeqc/dnarnadeseq/tests/main.nf.test.snap
+++ b/modules/local/maeqc/dnarnadeseq/tests/main.nf.test.snap
@@ -7,36 +7,36 @@
                         {
                             "id": "HG00096"
                         },
-                        "HG00096.Rds:md5,11f5b15dd847300c9cc03e1db1f30695"
+                        "HG00096.Rds:md5,0f0acaecfc4e6770f9eb84738a7da7b3"
                     ],
                     [
                         {
                             "id": "HG00103"
                         },
-                        "HG00103.Rds:md5,4782732b201cff97b9168e682a112aa6"
+                        "HG00103.Rds:md5,464c8977c58a928cb9f08589db0064df"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,0e71a9ff27c574a8542210cf36192972",
-                    "versions.yml:md5,0e71a9ff27c574a8542210cf36192972"
+                    "versions.yml:md5,f16eb030dcd808edc1a3ffef060b4eec",
+                    "versions.yml:md5,f16eb030dcd808edc1a3ffef060b4eec"
                 ],
                 "ods_with_pvals": [
                     [
                         {
                             "id": "HG00096"
                         },
-                        "HG00096.Rds:md5,11f5b15dd847300c9cc03e1db1f30695"
+                        "HG00096.Rds:md5,0f0acaecfc4e6770f9eb84738a7da7b3"
                     ],
                     [
                         {
                             "id": "HG00103"
                         },
-                        "HG00103.Rds:md5,4782732b201cff97b9168e682a112aa6"
+                        "HG00103.Rds:md5,464c8977c58a928cb9f08589db0064df"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,0e71a9ff27c574a8542210cf36192972",
-                    "versions.yml:md5,0e71a9ff27c574a8542210cf36192972"
+                    "versions.yml:md5,f16eb030dcd808edc1a3ffef060b4eec",
+                    "versions.yml:md5,f16eb030dcd808edc1a3ffef060b4eec"
                 ]
             }
         ],
@@ -44,7 +44,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T13:39:12.598556645"
+        "timestamp": "2025-09-11T13:24:10.450689926"
     },
     "homo_sapiens - counts - stub": {
         "content": [
@@ -58,7 +58,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,0e71a9ff27c574a8542210cf36192972"
+                    "versions.yml:md5,f16eb030dcd808edc1a3ffef060b4eec"
                 ],
                 "ods_with_pvals": [
                     [
@@ -69,7 +69,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,0e71a9ff27c574a8542210cf36192972"
+                    "versions.yml:md5,f16eb030dcd808edc1a3ffef060b4eec"
                 ]
             }
         ],
@@ -77,6 +77,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-12T13:39:24.230861351"
+        "timestamp": "2025-09-11T13:24:28.69271683"
     }
 }

--- a/modules/local/outrider/fit/environment.yml
+++ b/modules/local/outrider/fit/environment.yml
@@ -7,5 +7,12 @@ dependencies:
   - conda-forge::r-data.table=1.17.0
   - conda-forge::r-ggplot2=3.5.2
   - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-ggthemes=5.1.0
+  - conda-forge::r-tidyr=1.3.1
   - bioconda::bioconductor-outrider=1.24.0
   - bioconda::bioconductor-summarizedexperiment=1.36.0
+  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - bioconda::bioconductor-genomicalignments=1.42.0

--- a/modules/local/outrider/fit/main.nf
+++ b/modules/local/outrider/fit/main.nf
@@ -4,8 +4,8 @@ process OUTRIDER_FIT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c7/c76d0f6d35c84c2e9f9b883f1d7683c1fbdc09e8b8019f38b0915cc038dfd76f/data' :
-        'community.wave.seqera.io/library/bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-data.table_pruned:bf4693f792c006ff' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7c/7ce5b3968fffff40e5f0ee411b06d26c117985c558d976181e5b3d8575bf3b89/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:536d062a9b8ef2c5' }"
 
     input:
     tuple val(meta), path(ods)

--- a/modules/local/outrider/pvals/environment.yml
+++ b/modules/local/outrider/pvals/environment.yml
@@ -2,11 +2,17 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - conda-forge::r-base=4.4.3
+  - conda-forge::r-magrittr=2.0.3
+  - conda-forge::r-data.table=1.17.0
+  - conda-forge::r-ggplot2=3.5.2
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-ggthemes=5.1.0
+  - conda-forge::r-tidyr=1.3.1
   - bioconda::bioconductor-outrider=1.24.0
   - bioconda::bioconductor-summarizedexperiment=1.36.0
-  - conda-forge::r-base=4.4.3
-  - conda-forge::r-dplyr=1.1.4
-  - conda-forge::r-ggplot2=3.5.2
-  - conda-forge::r-magrittr=2.0.3
-  - conda-forge::r-yaml=2.3.10
-  - conda-forge::r-data.table=1.17.2
+  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - bioconda::bioconductor-genomicalignments=1.42.0

--- a/modules/local/outrider/pvals/environment.yml
+++ b/modules/local/outrider/pvals/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - conda-forge::r-ggplot2=3.5.2
   - conda-forge::r-magrittr=2.0.3
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-data.table=1.17.2

--- a/modules/local/outrider/pvals/main.nf
+++ b/modules/local/outrider/pvals/main.nf
@@ -4,8 +4,8 @@ process OUTRIDER_PVALS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/65/6586ceea612bc211a55c10d444e660c29be0ca3087538a06fce79267d07a82f7/data' :
-        'community.wave.seqera.io/library/bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-dplyr_pruned:0b2146d44ef9304b' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8b/8b06494957b33dc431981cb253bee86c5a0261314cb9295adaf3fbcf9027af77/data' :
+        'community.wave.seqera.io/library/bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-data.table_pruned:14d897661056024e' }"
 
     input:
     tuple val(meta) , path(ods_fitted), val(ids), path(gene_name_mapping)

--- a/modules/local/outrider/pvals/main.nf
+++ b/modules/local/outrider/pvals/main.nf
@@ -4,8 +4,8 @@ process OUTRIDER_PVALS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8b/8b06494957b33dc431981cb253bee86c5a0261314cb9295adaf3fbcf9027af77/data' :
-        'community.wave.seqera.io/library/bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-data.table_pruned:14d897661056024e' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7c/7ce5b3968fffff40e5f0ee411b06d26c117985c558d976181e5b3d8575bf3b89/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:536d062a9b8ef2c5' }"
 
     input:
     tuple val(meta) , path(ods_fitted), val(ids), path(gene_name_mapping)

--- a/modules/local/outrider/pvals/tests/main.nf.test
+++ b/modules/local/outrider/pvals/tests/main.nf.test
@@ -33,7 +33,7 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.ods_with_pvals,
+                    process.out.ods_with_pvals.collect { meta, r -> [ meta, file(r).name ] },
                     process.out.versions
                 ).match() }
             )

--- a/modules/local/outrider/pvals/tests/main.nf.test
+++ b/modules/local/outrider/pvals/tests/main.nf.test
@@ -32,7 +32,10 @@ nextflow_process {
         then {
             assertAll (
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.ods_with_pvals,
+                    process.out.versions
+                ).match() }
             )
         }
     }

--- a/modules/local/outrider/pvals/tests/main.nf.test.snap
+++ b/modules/local/outrider/pvals/tests/main.nf.test.snap
@@ -10,14 +10,14 @@
                 ]
             ],
             [
-                "versions.yml:md5,576a9cbc39fc6020faaa0f7a0465f024"
+                "versions.yml:md5,a703c6740a18e66bdf0fa097879a49ae"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-09T11:30:56.31842866"
+        "timestamp": "2025-09-10T19:37:21.117967803"
     },
     "homo_sapiens - ods fitted - stub": {
         "content": [
@@ -31,7 +31,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,576a9cbc39fc6020faaa0f7a0465f024"
+                    "versions.yml:md5,a703c6740a18e66bdf0fa097879a49ae"
                 ],
                 "ods_with_pvals": [
                     [
@@ -42,14 +42,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,576a9cbc39fc6020faaa0f7a0465f024"
+                    "versions.yml:md5,a703c6740a18e66bdf0fa097879a49ae"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-05-19T11:02:03.425299783"
+        "timestamp": "2025-09-10T19:37:40.100778901"
     }
 }

--- a/modules/local/outrider/pvals/tests/main.nf.test.snap
+++ b/modules/local/outrider/pvals/tests/main.nf.test.snap
@@ -1,36 +1,23 @@
 {
     "homo_sapiens - ods fitted": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.Rds:md5,b0697690e09bf9580c6638b10dbed461"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,576a9cbc39fc6020faaa0f7a0465f024"
-                ],
-                "ods_with_pvals": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.Rds:md5,b0697690e09bf9580c6638b10dbed461"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,576a9cbc39fc6020faaa0f7a0465f024"
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.Rds:md5,593980dbef1fb45658a01213da5e285a"
                 ]
-            }
+            ],
+            [
+                "versions.yml:md5,576a9cbc39fc6020faaa0f7a0465f024"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-05-19T11:01:54.497853636"
+        "timestamp": "2025-09-09T10:13:16.839005522"
     },
     "homo_sapiens - ods fitted - stub": {
         "content": [

--- a/modules/local/outrider/pvals/tests/main.nf.test.snap
+++ b/modules/local/outrider/pvals/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "test"
                     },
-                    "test.Rds:md5,593980dbef1fb45658a01213da5e285a"
+                    "test.Rds"
                 ]
             ],
             [
@@ -17,7 +17,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-09T10:13:16.839005522"
+        "timestamp": "2025-09-09T11:30:56.31842866"
     },
     "homo_sapiens - ods fitted - stub": {
         "content": [

--- a/modules/local/outrider/results/environment.yml
+++ b/modules/local/outrider/results/environment.yml
@@ -2,10 +2,17 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
-- bioconda::bioconductor-outrider=1.24.0
-- bioconda::bioconductor-summarizedexperiment=1.36.0
-- conda-forge::r-base=4.4.3
-- conda-forge::r-data.table=1.17.2
-- conda-forge::r-dplyr=1.1.4
-- conda-forge::r-ggplot2=3.5.2
-- conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-base=4.4.3
+  - conda-forge::r-magrittr=2.0.3
+  - conda-forge::r-data.table=1.17.0
+  - conda-forge::r-ggplot2=3.5.2
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-ggthemes=5.1.0
+  - conda-forge::r-tidyr=1.3.1
+  - bioconda::bioconductor-outrider=1.24.0
+  - bioconda::bioconductor-summarizedexperiment=1.36.0
+  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - bioconda::bioconductor-genomicalignments=1.42.0

--- a/modules/local/outrider/results/main.nf
+++ b/modules/local/outrider/results/main.nf
@@ -4,8 +4,8 @@ process OUTRIDER_RESULTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6c/6c8fca80b4b4c8ff2f44bd111d9dba954ae705231847b80315f8e5bc14bf1c67/data' :
-        'community.wave.seqera.io/library/bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-data.table_pruned:467a1248bdf03a95' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7c/7ce5b3968fffff40e5f0ee411b06d26c117985c558d976181e5b3d8575bf3b89/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:536d062a9b8ef2c5' }"
 
     input:
     tuple val(meta), path(ods), path(gene_name_mapping)

--- a/modules/local/outrider/results/tests/main.nf.test.snap
+++ b/modules/local/outrider/results/tests/main.nf.test.snap
@@ -19,7 +19,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,86ccc4c3ea012e12553ecf8dce1d5927"
+                    "versions.yml:md5,19a251474aefaa04bdd786dbaff2c2f8"
                 ],
                 "results": [
                     [
@@ -38,15 +38,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,86ccc4c3ea012e12553ecf8dce1d5927"
+                    "versions.yml:md5,19a251474aefaa04bdd786dbaff2c2f8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-05-22T16:54:44.035469969"
+        "timestamp": "2025-09-10T19:43:05.565381644"
     },
     "homo_sapiens - ods - stub": {
         "content": [
@@ -68,7 +68,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,86ccc4c3ea012e12553ecf8dce1d5927"
+                    "versions.yml:md5,19a251474aefaa04bdd786dbaff2c2f8"
                 ],
                 "results": [
                     [
@@ -87,14 +87,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,86ccc4c3ea012e12553ecf8dce1d5927"
+                    "versions.yml:md5,19a251474aefaa04bdd786dbaff2c2f8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-05-19T13:05:06.603468395"
+        "timestamp": "2025-09-10T19:43:24.228168567"
     }
 }

--- a/modules/local/outrider/summary/environment.yml
+++ b/modules/local/outrider/summary/environment.yml
@@ -3,10 +3,16 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::r-base=4.4.3
-  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-magrittr=2.0.3
   - conda-forge::r-data.table=1.17.0
   - conda-forge::r-ggplot2=3.5.2
-  - conda-forge::r-ggthemes=5.1.0
   - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-r.utils=2.13.0
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-ggthemes=5.1.0
+  - conda-forge::r-tidyr=1.3.1
   - bioconda::bioconductor-outrider=1.24.0
   - bioconda::bioconductor-summarizedexperiment=1.36.0
+  - bioconda::bioconductor-genomicfeatures=1.58.0
+  - bioconda::bioconductor-genomicalignments=1.42.0

--- a/modules/local/outrider/summary/main.nf
+++ b/modules/local/outrider/summary/main.nf
@@ -4,8 +4,8 @@ process OUTRIDER_SUMMARY {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/02/02b44404c5bf450fc2ec0a3247408b09096e0f429afc4c4ad4cf46f06238a110/data' :
-        'community.wave.seqera.io/library/bioconductor-outrider_bioconductor-summarizedexperiment_r-base_r-cowplot_pruned:0059eff556e3bc37' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7c/7ce5b3968fffff40e5f0ee411b06d26c117985c558d976181e5b3d8575bf3b89/data' :
+        'community.wave.seqera.io/library/bioconductor-genomicalignments_bioconductor-genomicfeatures_bioconductor-outrider_bioconductor-summarizedexperiment_pruned:536d062a9b8ef2c5' }"
 
     input:
     tuple val(meta), path(ods), path(results), val(drop_group), val(annotation_id)

--- a/modules/local/splicecounts/collectcounts/environment.yml
+++ b/modules/local/splicecounts/collectcounts/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/splicecounts/collectcounts/main.nf
+++ b/modules/local/splicecounts/collectcounts/main.nf
@@ -5,8 +5,8 @@ process SPLICECOUNTS_COLLECTCOUNTS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), path(splitcounts_granges), path(splicesites_splitcounts), val(drop_group)

--- a/modules/local/splicecounts/countnonsplitreads/environment.yml
+++ b/modules/local/splicecounts/countnonsplitreads/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/splicecounts/countnonsplitreads/main.nf
+++ b/modules/local/splicecounts/countnonsplitreads/main.nf
@@ -6,8 +6,8 @@ process SPLICECOUNTS_COUNTNONSPLITREADS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), path(splice_sites), path(bam), path(bai), val(drop_group), val(sample_id)

--- a/modules/local/splicecounts/countsplitreads/environment.yml
+++ b/modules/local/splicecounts/countsplitreads/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/splicecounts/countsplitreads/main.nf
+++ b/modules/local/splicecounts/countsplitreads/main.nf
@@ -5,8 +5,8 @@ process SPLICECOUNTS_COUNTSPLITREADS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: 'input/savedObjects/*'), path(bam), path(bai), val(drop_group), val(sample_id)

--- a/modules/local/splicecounts/init/environment.yml
+++ b/modules/local/splicecounts/init/environment.yml
@@ -2,11 +2,14 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - bioconda::bioconductor-bsgenome.hsapiens.ucsc.hg19=1.4.3
+  - bioconda::bioconductor-bsgenome.hsapiens.ucsc.hg38=1.4.5
+  - bioconda::bioconductor-bsgenome=1.74.0
   - bioconda::bioconductor-delayedmatrixstats=1.28.0
   - bioconda::bioconductor-fraser=2.2.0
   - bioconda::bioconductor-genomicalignments=1.42.0
-  - conda-forge::r-base=4.4.3
   - conda-forge::r-bbmisc=1.13
+  - conda-forge::r-biocmanager=1.30.25
   - conda-forge::r-data.table=1.17.4
   - conda-forge::r-devtools=2.4.5
   - conda-forge::r-dplyr=1.1.4
@@ -16,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/splicecounts/init/main.nf
+++ b/modules/local/splicecounts/init/main.nf
@@ -5,8 +5,8 @@ process SPLICECOUNTS_INIT {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/dc/dc5b31e03713c86445cb08c02014dda9298c2c0a7b20a17cda43abc66f6eb63c/data' :
-        'community.wave.seqera.io/library/bioconductor-delayedmatrixstats_bioconductor-fraser_bioconductor-genomicalignments_r-base_pruned:8f3a9483f1399b0a' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(col_data), val(drop_group)

--- a/modules/local/splicecounts/mergenonsplitreads/environment.yml
+++ b/modules/local/splicecounts/mergenonsplitreads/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/splicecounts/mergenonsplitreads/main.nf
+++ b/modules/local/splicecounts/mergenonsplitreads/main.nf
@@ -5,8 +5,8 @@ process SPLICECOUNTS_MERGENONSPLITREADS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), path(non_split_counts_granges), path(non_split_reads, stageAs:"input/cache/nonSplicedCounts/raw-local/*"), path(bams), path(bais), val(drop_group)

--- a/modules/local/splicecounts/mergesplitreads/environment.yml
+++ b/modules/local/splicecounts/mergesplitreads/environment.yml
@@ -19,3 +19,5 @@ dependencies:
   - conda-forge::r-rmarkdown=2.29
   - conda-forge::r-tidyr=1.3.1
   - conda-forge::r-yaml=2.3.10
+  - conda-forge::r-cowplot=1.1.3
+  - conda-forge::r-rcolorbrewer=1.1_3

--- a/modules/local/splicecounts/mergesplitreads/main.nf
+++ b/modules/local/splicecounts/mergesplitreads/main.nf
@@ -5,8 +5,8 @@ process SPLICECOUNTS_MERGESPLITREADS {
     // TODO discuss if this container should be split up, library loading should be done in the module script instead in that case
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3e8560898529101d3e70df5dc164124740084c05a48ced2baf0128379825d04e/data' :
-        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:6ecb1e6b5187b515' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c87aab5452ff7d6a9344148e284ca01a8c5d2239d7b0f26164da1806a8c59875/data' :
+        'community.wave.seqera.io/library/bioconductor-bsgenome.hsapiens.ucsc.hg19_bioconductor-bsgenome.hsapiens.ucsc.hg38_bioconductor-bsgenome_bioconductor-delayedmatrixstats_pruned:b2aa4004c588aaaf' }"
 
     input:
     tuple val(meta), path(fds, stageAs: "input/savedObjects/*"), path(split_counts, stageAs: "input/cache/splitCounts/*"), path(bams), path(bais), val(drop_group)


### PR DESCRIPTION
When running nf-tests with conda, some snaps failed. This PR tries to solve the issue.

- fraser/calculatestats: some output h5 files differes in bits, I do not check md5 for them
- outrider/pvals: output RDS file is stable within docker and within conda, but differs between docker and conda (seems in bit).  I do not check md5 for the RDS file for now but I am open for any comment.
- mae/alleliccounts and mae/createsnvs: after add minor version of the packages, versions between docker and conda get stable
- solves #75 . It seems that singularity container is not right.
 