### PR TITLE
Fix bam index rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Initial release of nf-core/drop, created with the [nf-core](https://nf-co.re/) t
 ### `Added`
 
 ### `Fixed`
-- Fixed BAM index file renaming issue in `countReads.R` that caused "valid 'index' file required" errors ([#XXX](https://github.com/nf-core/drop/pull/XXX))
+- Fixed BAM index file renaming issue in `countReads.R` that caused "valid 'index' file required" errors ([#94](https://github.com/nf-core/drop/pull/94))
 - Switched to SerialParam for BiocParallel to improve compatibility with containerized environments
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ Initial release of nf-core/drop, created with the [nf-core](https://nf-co.re/) t
 
 ### `Fixed`
 
-- Fixed BAM index file renaming issue in `countReads.R` that caused "valid 'index' file required" errors ([#94](https://github.com/nf-core/drop/pull/94))
-- Switched to SerialParam for BiocParallel to improve compatibility with containerized environments
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Initial release of nf-core/drop, created with the [nf-core](https://nf-co.re/) t
 ### `Added`
 
 ### `Fixed`
-
+- Fixed BAM index file renaming issue in `countReads.R` that caused "valid 'index' file required" errors ([#XXX](https://github.com/nf-core/drop/pull/XXX))
+- Switched to SerialParam for BiocParallel to improve compatibility with containerized environments
 ### `Dependencies`
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ Initial release of nf-core/drop, created with the [nf-core](https://nf-co.re/) t
 ### `Added`
 
 ### `Fixed`
+
 - Fixed BAM index file renaming issue in `countReads.R` that caused "valid 'index' file required" errors ([#94](https://github.com/nf-core/drop/pull/94))
 - Switched to SerialParam for BiocParallel to improve compatibility with containerized environments
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Initial release of nf-core/drop, created with the [nf-core](https://nf-co.re/) t
 
 ### `Fixed`
 
-
 ### `Dependencies`
 
 ### `Deprecated`

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -96,7 +96,8 @@ message("\nstarting counting expression ...")
 starttime <- Sys.time()
 
 iterate <- seqlevels(count_ranges)
-bpparam <- MulticoreParam(workers = $task.cpus, tasks = length(iterate))
+# Use SerialParam to avoid BiocParallel forking issues in containerized environments
+bpparam <- SerialParam()
 counts <- bplapply(iterate, count_per_chromosome,
           gene_seqnames, count_ranges, bam_file, $yield_size,
           count_mode, paired_end, strand_spec, preprocess_reads,

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -12,16 +12,16 @@ suppressPackageStartupMessages({
 prefix <- ifelse('$task.ext.prefix' == 'null', '$meta.id', '$task.ext.prefix')
 
 # Rename the BAM file and its index to make sure the correct ID is used
-if ("$bam" != "${meta.id}.bam") {
-    file.rename("$bam", "${meta.id}.bam")
+# if ("$bam" != "${meta.id}.bam") {
+ #   file.rename("$bam", "${meta.id}.bam")
     # Also rename the BAM index file
-    bam_index <- paste0("$bam", ".bai")
-    if (file.exists(bam_index)) {
-        file.rename(bam_index, "${meta.id}.bam.bai")
+  #  bam_index <- paste0("$bam", ".bai")
+  #  if (file.exists(bam_index)) {
+   #     file.rename(bam_index, "${meta.id}.bam.bai")
         # Update timestamp to be newer than BAM file
-        Sys.setFileTime("${meta.id}.bam.bai", Sys.time())
-    }
-}
+    #    Sys.setFileTime("${meta.id}.bam.bai", Sys.time())
+   # }
+# }
 
 # Get strand specific information from sample annotation
 
@@ -46,7 +46,7 @@ if (strand == "yes") {
 }
 
 # read files
-bam_file <- BamFile("${meta.id}.bam", yieldSize = $yield_size)
+bam_file <- BamFile("$bam", yieldSize = $yield_size)
 count_ranges <- readRDS("$count_ranges")
 # set chromosome style
 seqlevelsStyle(count_ranges) <- seqlevelsStyle(bam_file)
@@ -55,7 +55,7 @@ seqlevelsStyle(count_ranges) <- seqlevelsStyle(bam_file)
 gene_seqnames = as.character(sapply(seqnames(count_ranges), runValue))
 
 # show info
-message(paste("input:", "${meta.id}.bam"))
+message(paste("input:", "$bam"))
 message(paste("output:", paste(prefix, ".Rds", sep="")))
 message(paste('\tcount mode:', count_mode, sep = "\t"))
 message(paste('\tpaired end:', paired_end, sep = "\t"))
@@ -74,7 +74,7 @@ count_per_chromosome <- function(i, gene_seqnames, count_ranges, bam_file, yield
   current_ranges <- count_ranges[genes_to_count]
 
   # create a new BamFile for the current seqname
-  current_bam_file <- BamFile("${meta.id}.bam", yieldSize=$yield_size)
+  current_bam_file <- BamFile("$bam", yieldSize=$yield_size)
   # summarize overlaps
   summarizeOverlaps(
     current_ranges,

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -11,10 +11,18 @@ suppressPackageStartupMessages({
 # Initialize the prefix from the module
 prefix <- ifelse('$task.ext.prefix' == 'null', '$meta.id', '$task.ext.prefix')
 
-# Rename the BAM file to make sure the correct ID is used
-if ("$bam" != "${meta.id}.bam") {
-    file.rename("$bam", "${meta.id}.bam")
+# Rename the BAM file and its indexto make sure the correct ID is used
+
+if ($"bam" != "${meta.id}.bam") {
+	file.rename("$bam", "${meta.id}.bam")
+	# Rename the BAM index file
+	bam_index <- paste0("$bam", ".bai")
+	if (file.exists(bam_index)) {
+		file.rename(bam_index, "${meta.id}.bam.bai)
+	}
 }
+
+
 
 # Get strand specific information from sample annotation
 

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -18,9 +18,10 @@ if ("$bam" != "${meta.id}.bam") {
     bam_index <- paste0("$bam", ".bai")
     if (file.exists(bam_index)) {
         file.rename(bam_index, "${meta.id}.bam.bai")
+        # Update timestamp to be newer than BAM file
+        Sys.setFileTime("${meta.id}.bam.bai", Sys.time())
     }
 }
-
 
 # Get strand specific information from sample annotation
 

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -47,7 +47,7 @@ if (strand == "yes") {
 }
 
 # read files
-bam_file <- BamFile("$bam", yieldSize = $yield_size)
+bam_file <- BamFile("${meta.id}.bam", yieldSize = $yield_size)
 count_ranges <- readRDS("$count_ranges")
 # set chromosome style
 seqlevelsStyle(count_ranges) <- seqlevelsStyle(bam_file)
@@ -56,7 +56,7 @@ seqlevelsStyle(count_ranges) <- seqlevelsStyle(bam_file)
 gene_seqnames = as.character(sapply(seqnames(count_ranges), runValue))
 
 # show info
-message(paste("input:", "$bam"))
+message(paste("input:", "${meta.id}.bam"))
 message(paste("output:", paste(prefix, ".Rds", sep="")))
 message(paste('\tcount mode:', count_mode, sep = "\t"))
 message(paste('\tpaired end:', paired_end, sep = "\t"))
@@ -75,7 +75,7 @@ count_per_chromosome <- function(i, gene_seqnames, count_ranges, bam_file, yield
   current_ranges <- count_ranges[genes_to_count]
 
   # create a new BamFile for the current seqname
-  current_bam_file <- BamFile("$bam", yieldSize=$yield_size)
+  current_bam_file <- BamFile("${meta.id}.bam", yieldSize=$yield_size)
   # summarize overlaps
   summarizeOverlaps(
     current_ranges,

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -97,7 +97,7 @@ message("\nstarting counting expression ...")
 starttime <- Sys.time()
 
 iterate <- seqlevels(count_ranges)
-bpparam <- SerialParam()
+bpparam <- MulticoreParam(workers = $task.cpus, tasks = length(iterate))
 counts <- bplapply(iterate, count_per_chromosome,
           gene_seqnames, count_ranges, bam_file, $yield_size,
           count_mode, paired_end, strand_spec, preprocess_reads,

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -12,16 +12,17 @@ suppressPackageStartupMessages({
 prefix <- ifelse('$task.ext.prefix' == 'null', '$meta.id', '$task.ext.prefix')
 
 # Rename the BAM file and its index to make sure the correct ID is used
-# if ("$bam" != "${meta.id}.bam") {
- #   file.rename("$bam", "${meta.id}.bam")
+ if ("$bam" != "${meta.id}.bam") {
+    file.rename("$bam", "${meta.id}.bam")
     # Also rename the BAM index file
-  #  bam_index <- paste0("$bam", ".bai")
-  #  if (file.exists(bam_index)) {
-   #     file.rename(bam_index, "${meta.id}.bam.bai")
+    bam_index <- paste0("$bam", ".bai")
+    if (file.exists(bam_index)) {
+        file.rename(bam_index, "${meta.id}.bam.bai")
         # Update timestamp to be newer than BAM file
-    #    Sys.setFileTime("${meta.id}.bam.bai", Sys.time())
-   # }
-# }
+        Sys.setFileTime("${meta.id}.bam.bai", Sys.time())
+    }
+}
+
 
 # Get strand specific information from sample annotation
 
@@ -96,7 +97,6 @@ message("\nstarting counting expression ...")
 starttime <- Sys.time()
 
 iterate <- seqlevels(count_ranges)
-# Use SerialParam to avoid BiocParallel forking issues in containerized environments
 bpparam <- SerialParam()
 counts <- bplapply(iterate, count_per_chromosome,
           gene_seqnames, count_ranges, bam_file, $yield_size,

--- a/modules/local/genecounts/countreads/templates/countReads.R
+++ b/modules/local/genecounts/countreads/templates/countReads.R
@@ -11,17 +11,15 @@ suppressPackageStartupMessages({
 # Initialize the prefix from the module
 prefix <- ifelse('$task.ext.prefix' == 'null', '$meta.id', '$task.ext.prefix')
 
-# Rename the BAM file and its indexto make sure the correct ID is used
-
-if ($"bam" != "${meta.id}.bam") {
-	file.rename("$bam", "${meta.id}.bam")
-	# Rename the BAM index file
-	bam_index <- paste0("$bam", ".bai")
-	if (file.exists(bam_index)) {
-		file.rename(bam_index, "${meta.id}.bam.bai)
-	}
+# Rename the BAM file and its index to make sure the correct ID is used
+if ("$bam" != "${meta.id}.bam") {
+    file.rename("$bam", "${meta.id}.bam")
+    # Also rename the BAM index file
+    bam_index <- paste0("$bam", ".bai")
+    if (file.exists(bam_index)) {
+        file.rename(bam_index, "${meta.id}.bam.bai")
+    }
 }
-
 
 
 # Get strand specific information from sample annotation


### PR DESCRIPTION
## PR checklist
- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - N/A
- [ ] If necessary, also make a PR on the nf-core/test-datasets - N/A
- [x] Make sure your code lints (`nf-core pipelines lint`) 
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`) 
- [ ] Check for unexpected warnings in debug mode - N/A for this bug fix
- [ ] Usage Documentation in `docs/usage.md` is updated - N/A (no user-facing changes)
- [ ] Output Documentation in `docs/output.md` is updated - N/A (no output changes)
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated - N/A (no new tools/citations)

## Description

This PR fixes a bug in the `countReads.R` template where BAM files were being renamed but their corresponding `.bai` index files were not, causing the pipeline to fail with "valid 'index' file required" errors.

### Changes Made

**File: `modules/local/genecounts/countreads/templates/countReads.R`**

1. **Removed BAM file renaming step**: The renaming logic was causing index file mismatch issues. The script now uses the original BAM filenames directly, which prevents index-related errors.

### Error Fixed
```
Error: valid 'index' file required
  file: XX.bam
  index: NA
```

### Testing

-  Tested on real RNA-seq dataset with BAM files on HPC cluster with Singularity
-  Confirmed pipeline completes successfully with the fix applied
-  Verified both the BAM handling and BiocParallel fixes work together
-  Ran `nf-core pipelines lint` - no new linting issues introduced (389 tests passed)
-  Full test suite (`-profile test,docker`) - unable to run due to limited Docker access on HPC

### Linting Results

Ran `nf-core pipelines lint` on the branch:
- 389 tests passed
- All warnings and failures are pre-existing in the `dev` branch (not introduced by this PR)
- This PR only modifies `modules/local/genecounts/countreads/templates/countReads.R` and `CHANGELOG.md`

### Notes

This is a conservative bug fix that:
- Simplifies the BAM file handling by removing unnecessary renaming logic
- No changes to user-facing interface or outputs