### PR TITLE
fix ae_include_gruops

### DIFF
--- a/subworkflows/local/aberrantexpression/main.nf
+++ b/subworkflows/local/aberrantexpression/main.nf
@@ -90,7 +90,9 @@ workflow ABERRANTEXPRESSION {
     def mergereads_input = GENECOUNTS_COUNTREADS.out.counts
         .mix(inputs_branch.counts_present)
         .map { meta, count ->
-            [ meta, count, meta.drop_group.tokenize(",").intersect(include_groups) ]
+            def all_groups = meta.drop_group.tokenize(",")
+            def target_groups = include_groups ? all_groups.intersect(include_groups) : all_groups
+            [meta, count, target_groups]
         }
         .transpose(by: 2) // Split the entries per included group
         .map { meta, count, group ->


### PR DESCRIPTION
Aberrant expression was not fully running if no group was provided using --ae_groups. Since
`meta.drop_group.tokenize(",").intersect(include_groups)`
results in an empty string if `include_groups` is empty.
 This pr fixes that. 